### PR TITLE
Fix logic to parse HTTP header values

### DIFF
--- a/get_graphql_schema.go
+++ b/get_graphql_schema.go
@@ -59,11 +59,11 @@ func parseHeaderOption(headers string) (http.Header, error) {
 	}
 
 	for _, h := range strings.Split(headers, ",") {
-		kv := strings.Split(h, "=")
-		if len(kv) != 2 {
+		key, value, found := strings.Cut(h, "=")
+		if !found {
 			return nil, fmt.Errorf("invalid header: %s", h)
 		}
-		header.Add(kv[0], kv[1])
+		header.Add(key, value)
 	}
 	return header, nil
 }


### PR DESCRIPTION
There is a problem where if an equals sign (=) is included in the value of an HTTP header, it is technically correct but triggers a validation error. Therefore, by using the strings.Cut function to split the string at the first equals sign in the HTTP header, I have made a modification to ensure that equals signs included in the value are also retained.